### PR TITLE
Presentable Portfolio

### DIFF
--- a/src/components/ContactFormModal.tsx
+++ b/src/components/ContactFormModal.tsx
@@ -62,7 +62,7 @@ export default function ContactFormModal({ ...props }) {
 
   useEffect(() => {
     switch(loc) {
-      case 'home': setTo('@thisispalash'); break;
+      case 'home': setTo('@isthispalash'); break;
       case 'kdio': 
         setTo('@kdio'); 
         setBgModal('bgAlternate'); 

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,13 +1,21 @@
-import { AspectRatio, Divider, HStack, Image, Link, Spacer, Text, useDisclosure, VStack } from '@chakra-ui/react';
+import { AspectRatio, Divider, HStack, Image, Link, Spacer, Text, Tooltip, useDisclosure, VStack } from '@chakra-ui/react';
 import Head from '@/components/Head';
 import ContactFormModal from '@/components/ContactFormModal';
+import { useGlobalContext } from '@/context/GlobalContext';
 
 export default function Home() {
 
   const { isOpen, onOpen, onClose } = useDisclosure();
+  
+  // @ts-ignore
+  const { makeToast } = useGlobalContext();
 
   const contact = () => {
     onOpen();
+  }
+
+  const canaryToast = () => {
+    makeToast({ code: 501, title: 'Canary Feature!' });
   }
 
   return (
@@ -21,21 +29,35 @@ export default function Home() {
         <HStack spacing={8} px={12} py={12} w='full'>
           <Spacer />
           <AspectRatio ratio={1} w='225px' h='225px'>
-            <Image src='/images/balli-no-bg.png' alt='thisispalash' onClick={contact} className='cursor-message' />
+            <Tooltip label='Contact Me' aria-label='Contact Me'>
+              <Image src='/images/balli-no-bg.png' alt='thisispalash' onClick={contact} className='cursor-message' />
+            </Tooltip>
           </AspectRatio>
           <VStack spacing={2} textAlign='left'>
             <Spacer />
             <Text w='full' fontSize='4xl' fontFamily='heading' fontWeight='semibold' color='highlight'>
               thisispalash{' '}
-              <Link href='https://open.spotify.com/user/palash96_rox?si=ebe624cfcf7b47b9' isExternal variant='reverse' className='cursor-spotify'>[</Link>
-              <Link href='https://twitter.com/kdiodna' isExternal variant='reverse' className='cursor-twitter'>d</Link>
-              <Link href='https://linkedin.com/in/isthispalash' isExternal variant='reverse' className='cursor-linkedin'>o</Link>
-              <Link href='https://twitter.com/theprimefibber' isExternal variant='reverse' className='cursor-twitter'>t</Link>
-              <Link href='https://instagram.com/isthispalash' isExternal variant='reverse' className='cursor-instagram'>]</Link>
+              <Tooltip label='Spotify' aria-label='Spotify'>
+                <Link href='https://open.spotify.com/user/palash96_rox?si=ebe624cfcf7b47b9' isExternal variant='reverse' className='cursor-spotify'>[</Link>
+              </Tooltip>
+              <Tooltip label='Twitter / X' aria-label='Twitter / X'>
+                <Link href='https://twitter.com/kdiodna' isExternal variant='reverse' className='cursor-twitter'>d</Link>
+              </Tooltip>
+              <Tooltip label='LinkedIn' aria-label='LinkedIn'>
+                <Link href='https://linkedin.com/in/isthispalash' isExternal variant='reverse' className='cursor-linkedin'>o</Link>
+              </Tooltip>
+              <Tooltip label='X / Twitter' aria-label='X / Twitter'>
+                <Link href='https://twitter.com/theprimefibber' isExternal variant='reverse' className='cursor-twitter'>t</Link>
+              </Tooltip>
+              <Tooltip label='Instagram' aria-label='Instagram'>
+                <Link href='https://instagram.com/isthispalash' isExternal variant='reverse' className='cursor-instagram'>]</Link>
+              </Tooltip>
               {' '}com
             </Text>
             <Text w='full' fontSize='lg'>
-              <Link href='https://github.com/thisispalash' isExternal className='cursor-github'>Decentralizing</Link>
+              <Tooltip label='GitHub' aria-label='GitHub'>
+                <Link href='https://github.com/thisispalash' isExternal className='cursor-github'>Decentralizing</Link>
+              </Tooltip>
               {' '}the world, one bit at a time!
             </Text>
             <Spacer />
@@ -53,9 +75,9 @@ export default function Home() {
             <Link href='/kdio' variant='reverse'>
               <Text fontFamily='heading' fontSize='lg'>khaaliDimaag [dot] io</Text>
             </Link>
-            <Link href='/b3' variant='reverse'>
-              <Text fontFamily='heading' fontSize='lg'>Bedside Blackboard</Text>
-            </Link>
+            <Text fontFamily='heading' fontSize='lg' onClick={canaryToast} variant='cilckableReverse'>
+              Bedside Blackboard
+            </Text>
             <Spacer />
           </HStack>
         </VStack>

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -26,16 +26,17 @@ export default function Home() {
           <VStack spacing={2} textAlign='left'>
             <Spacer />
             <Text w='full' fontSize='4xl' fontFamily='heading' fontWeight='semibold' color='highlight'>
-              thisispalash [
+              thisispalash{' '}
+              <Link href='https://open.spotify.com/user/palash96_rox?si=ebe624cfcf7b47b9' isExternal variant='reverse' className='cursor-spotify'>[</Link>
               <Link href='https://twitter.com/kdiodna' isExternal variant='reverse' className='cursor-twitter'>d</Link>
               <Link href='https://linkedin.com/in/isthispalash' isExternal variant='reverse' className='cursor-linkedin'>o</Link>
               <Link href='https://twitter.com/theprimefibber' isExternal variant='reverse' className='cursor-twitter'>t</Link>
-              ] com
+              <Link href='https://instagram.com/isthispalash' isExternal variant='reverse' className='cursor-instagram'>]</Link>
+              {' '}com
             </Text>
             <Text w='full' fontSize='lg'>
-              Decentralizing the world,{' '}
-              <Link href='https://github.com/thisispalash' isExternal className='cursor-github'>one Byte</Link>
-              {' '}at a time!
+              <Link href='https://github.com/thisispalash' isExternal className='cursor-github'>Decentralizing</Link>
+              {' '}the world, one bit at a time!
             </Text>
             <Spacer />
           </VStack>

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -72,10 +72,10 @@ export default function Home() {
           <Divider px={32} />
           <HStack spacing={8} px={12} textAlign='center'>
             <Spacer />
-            <Link href='/kdio' variant='reverse'>
+            <Link href='https://kdio.xyz' variant='reverse'>
               <Text fontFamily='heading' fontSize='lg'>khaaliDimaag [dot] io</Text>
             </Link>
-            <Text fontFamily='heading' fontSize='lg' onClick={canaryToast} variant='cilckableReverse'>
+            <Text fontFamily='heading' fontSize='lg' variant='cilckableReverse' onClick={canaryToast}>
               Bedside Blackboard
             </Text>
             <Spacer />

--- a/src/theme.ts
+++ b/src/theme.ts
@@ -121,6 +121,13 @@ const components = {
           color: 'highlight',
         }
       },
+      'cilckableReverse': {
+        cursor: 'pointer',
+        color: 'highlight',
+        _hover: {
+          color: 'text',
+        }
+      },
       'heading': {
         fontFamily: 'heading',
         fontSize: '2xl',


### PR DESCRIPTION
> closes #4

## Changes Made

- Tooltips added for all [bio] links
- Removed access to internal pages
  - _khaaliDimaag_ links out to `kdio.xyz`
  - _Bedside Blackboard_ is now a canary feature, user informed via toast
- Social links added and moved around.

## Further Work

- Create increasingly 1155 nfts ~ #5 
- Improve blogging capability ~ #2 
- Add in links to solo projects via a marquee on left link-out
- Add in signup for small screens ~ #8 